### PR TITLE
Allow setting seed to custom values in subsequent runs

### DIFF
--- a/veceval/helpers/utility_functions.py
+++ b/veceval/helpers/utility_functions.py
@@ -1,9 +1,10 @@
-import numpy as np
 import pickle
 import re
 import sys
-from keras.optimizers import Adagrad, Adadelta, RMSprop
+
+import numpy as np
 from keras.callbacks import EarlyStopping, ModelCheckpoint
+from keras.optimizers import Adagrad, Adadelta, RMSprop
 from keras.utils.np_utils import categorical_probas_to_classes
 from sklearn.metrics import f1_score
 
@@ -186,3 +187,7 @@ def calculate_f1(predictions, actual):
     return f1_score(categorical_probas_to_classes(actual),
                     categorical_probas_to_classes(predictions),
                     average="micro")
+
+
+def reset_seed(seed: int = SEED):
+    np.random.seed(seed)

--- a/veceval/training/chunk_finetuned.py
+++ b/veceval/training/chunk_finetuned.py
@@ -35,8 +35,8 @@ class ChunkFinetunedTrainer(Trainer):
                                       has_validation=False, is_testing=ve.IS_TESTING)
 
 
-def main_training(config_path, name):
-    np.random.seed(ve.SEED)
+def main_training(config_path, name, seed=ve.SEED):
+    ve.reset_seed(seed)
     trainer = ChunkFinetunedTrainer(config_path, name)
     trainer.train_and_test()
 

--- a/veceval/training/chunk_fixed.py
+++ b/veceval/training/chunk_fixed.py
@@ -34,8 +34,8 @@ class ChunkFixedTrainer(Trainer):
                                           has_validation=False, is_testing=ve.IS_TESTING)
 
 
-def main_training(config_path, name):
-    np.random.seed(ve.SEED)
+def main_training(config_path, name, seed=ve.SEED):
+    ve.reset_seed(seed)
     trainer = ChunkFixedTrainer(config_path, name)
     trainer.train_and_test()
 

--- a/veceval/training/ner_finetuned.py
+++ b/veceval/training/ner_finetuned.py
@@ -68,8 +68,8 @@ class NERFinetunedTrainer(Trainer):
         return set_to_evaluate, result
 
 
-def main_training(config_path, name):
-    np.random.seed(ve.SEED)
+def main_training(config_path, name, seed=ve.SEED):
+    ve.reset_seed(seed)
     trainer = NERFinetunedTrainer(config_path, name)
     trainer.train_and_test()
 

--- a/veceval/training/ner_fixed.py
+++ b/veceval/training/ner_fixed.py
@@ -49,8 +49,8 @@ class NERFixedTrainer(Trainer):
         return set_to_evaluate, result
 
 
-def main_training(config_path, name):
-    np.random.seed(ve.SEED)
+def main_training(config_path, name, seed=ve.SEED):
+    ve.reset_seed(seed)
     trainer = NERFixedTrainer(config_path, name)
     trainer.train_and_test()
 

--- a/veceval/training/nli_finetuned.py
+++ b/veceval/training/nli_finetuned.py
@@ -75,8 +75,8 @@ class NLIFinetunedTrainer(Trainer):
         return set_to_evaluate, acc
 
 
-def main_training(config_path, name):
-    np.random.seed(ve.SEED)
+def main_training(config_path, name, seed=ve.SEED):
+    ve.reset_seed(seed)
     trainer = NLIFinetunedTrainer(config_path, name)
     trainer.train_and_test()
 

--- a/veceval/training/nli_fixed.py
+++ b/veceval/training/nli_fixed.py
@@ -61,8 +61,8 @@ class NLIFixedTrainer(Trainer):
         return set_to_evaluate, acc
 
 
-def main_training(config_path, name):
-    np.random.seed(ve.SEED)
+def main_training(config_path, name, seed=ve.SEED):
+    ve.reset_seed(seed)
     trainer = NLIFixedTrainer(config_path, name)
     trainer.train_and_test()
 

--- a/veceval/training/pos_finetuned.py
+++ b/veceval/training/pos_finetuned.py
@@ -35,8 +35,8 @@ class POSFinetunedTrainer(Trainer):
         return model
 
 
-def main_training(config_path, name):
-    np.random.seed(ve.SEED)
+def main_training(config_path, name, seed=ve.SEED):
+    ve.reset_seed(seed)
     trainer = POSFinetunedTrainer(config_path, name)
     trainer.train_and_test()
 

--- a/veceval/training/pos_fixed.py
+++ b/veceval/training/pos_fixed.py
@@ -34,8 +34,8 @@ class POSFixedTrainer(Trainer):
         return model
 
 
-def main_training(config_path, name):
-    np.random.seed(ve.SEED)
+def main_training(config_path, name, seed=ve.SEED):
+    ve.reset_seed(seed)
     trainer = POSFixedTrainer(config_path, name)
     trainer.train_and_test()
 

--- a/veceval/training/questions_finetuned.py
+++ b/veceval/training/questions_finetuned.py
@@ -40,8 +40,8 @@ class QuestionsFinetunedTrainer(Trainer):
                             is_testing=ve.IS_TESTING)
 
 
-def main_training(config_path, name):
-    np.random.seed(ve.SEED)
+def main_training(config_path, name, seed=ve.SEED):
+    ve.reset_seed(seed)
     trainer = QuestionsFinetunedTrainer(config_path, name)
     trainer.train_and_test()
 

--- a/veceval/training/questions_fixed.py
+++ b/veceval/training/questions_fixed.py
@@ -33,8 +33,8 @@ class QuestionsFixedTrainer(Trainer):
                                 is_testing=ve.IS_TESTING)
 
 
-def main_training(config_path, name):
-    np.random.seed(ve.SEED)
+def main_training(config_path, name, seed=ve.SEED):
+    ve.reset_seed(seed)
     trainer = QuestionsFixedTrainer(config_path, name)
     trainer.train_and_test()
 

--- a/veceval/training/sentiment_finetuned.py
+++ b/veceval/training/sentiment_finetuned.py
@@ -40,8 +40,8 @@ class SentimentFinetunedTrainer(Trainer):
         return model
 
 
-def main_training(config_path, name):
-    np.random.seed(ve.SEED)
+def main_training(config_path, name, seed=ve.SEED):
+    ve.reset_seed(seed)
     trainer = SentimentFinetunedTrainer(config_path, name)
     trainer.train_and_test()
 

--- a/veceval/training/sentiment_fixed.py
+++ b/veceval/training/sentiment_fixed.py
@@ -34,8 +34,8 @@ class SentimentFixedTrainer(Trainer):
         return model
 
 
-def main_training(config_path, name):
-    np.random.seed(ve.SEED)
+def main_training(config_path, name, seed=ve.SEED):
+    ve.reset_seed(seed)
     trainer = SentimentFixedTrainer(config_path, name)
     trainer.train_and_test()
 

--- a/veceval/veceval_evaluate.py
+++ b/veceval/veceval_evaluate.py
@@ -1,9 +1,9 @@
+import importlib
 import os
-import sys
 from functools import partial
 
+from veceval.helpers.utility_functions import SEED
 from veceval.settings import CONFIGS_FOLDER, MODES, TASKS
-import importlib
 
 
 def compile_trainers():
@@ -23,13 +23,13 @@ def compile_trainers():
     return task_to_trainer
 
 
-def evaluate_embedding(embedding_name):
+def evaluate_embedding(embedding_name: str, seed: int = SEED):
     task_to_trainer = compile_trainers()
     for task_name, trainer in task_to_trainer.items():
         print(80 * "-")
         print(task_name.upper())
         print(80 * "-")
-        trainer(embedding_name)
+        trainer(embedding_name, seed=seed)
         print()
 
 


### PR DESCRIPTION
This PR adds an optional argument `seed` to `evaluate_embeddings`. This allows to specify a different random seed for different evaluation runs; hence allowing us to measure the sensitivity of the eavluation results to the specific value of the random seed.